### PR TITLE
Add servegoissues command for viewing Go issues locally (offline) in browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ func main() {
 	})
 }
 ```
+
+There is also a program that will display the issues in your browser.
+It will work when offline. Install it with
+`go get -u github.com/bradfitz/go-issue-mirror/cmd/servegoissues`,
+then run `servegoissues` and navigate to http://localhost:8080/ in your browser.

--- a/cmd/servegoissues/servegoissues.go
+++ b/cmd/servegoissues/servegoissues.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+
+	goissues "github.com/bradfitz/go-issue-mirror/issues"
+	"github.com/bradfitz/issuemirror"
+	"github.com/google/go-github/github"
+	"github.com/shurcooL/issues"
+	"github.com/shurcooL/issuesapp"
+	"github.com/shurcooL/issuesapp/common"
+	"github.com/shurcooL/users"
+	"golang.org/x/net/context"
+)
+
+var httpFlag = flag.String("http", ":8080", "Listen for HTTP connections on this address.")
+
+func main() {
+	flag.Parse()
+
+	root, err := goissues.Open()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// issuesapp requires an issues.Service and users.Service implementations.
+	// We provide a simple read-only implementation of issues.Service on top of root,
+	// and a no users service since this runs locally and doesn't need user authentication.
+	issuesApp := issuesapp.New(issuesService{root: root}, noUsersService{}, issuesapp.Options{
+		Context: func(req *http.Request) context.Context {
+			return context.TODO()
+		},
+		RepoSpec: func(req *http.Request) issues.RepoSpec {
+			return issues.RepoSpec{URI: "github.com/golang/go"}
+		},
+		BaseURI: func(req *http.Request) string {
+			return "."
+		},
+		BaseState: func(req *http.Request) issuesapp.BaseState {
+			reqPath := req.URL.Path
+			if reqPath == "/" {
+				reqPath = ""
+			}
+			return issuesapp.BaseState{
+				State: common.State{
+					BaseURI: ".",
+					ReqPath: reqPath,
+				},
+			}
+		},
+		HeadPre: `<style type="text/css">
+	body {
+		margin: 20px;
+		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+		font-size: 14px;
+		line-height: initial;
+		color: #373a3c;
+	}
+	a {
+		color: #0275d8;
+		text-decoration: none;
+	}
+	a:focus, a:hover {
+		color: #014c8c;
+		text-decoration: underline;
+	}
+	.btn {
+		font-size: 11px;
+		line-height: 11px;
+		border-radius: 4px;
+		border: solid #d2d2d2 1px;
+		background-color: #fff;
+		box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
+	}
+</style>`,
+	})
+
+	http.Handle("/", issuesApp)
+	http.HandleFunc("/login/github", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintln(w, "Sorry, this is a read-only instance and it doesn't support signing in.")
+	})
+
+	printServingAt(*httpFlag)
+	err = http.ListenAndServe(*httpFlag, nil)
+	if err != nil {
+		log.Fatalln("http.ListenAndServe:", err)
+	}
+}
+
+func printServingAt(addr string) {
+	hostPort := addr
+	if strings.HasPrefix(hostPort, ":") {
+		hostPort = "localhost" + hostPort
+	}
+	fmt.Printf("serving at http://%s/\n", hostPort)
+}
+
+// issuesService implements issues.Service using issuemirror.Root.
+// It's a view-only implementation at this time, so create and edit endpoints
+// are not implemented.
+type issuesService struct {
+	root issuemirror.Root
+}
+
+// List issues.
+func (s issuesService) List(ctx context.Context, repo issues.RepoSpec, opt issues.IssueListOptions) ([]issues.Issue, error) {
+	var is []issues.Issue
+
+	// TODO: Pagination support would be nice... But meh, it reads from local disk,
+	//       and the browser seems to render 14000+ issues on a single page pretty well.
+	//       So this isn't as critical or blocking as I expected. Besides, it's nice
+	//       to be able to do Cmd+F to find stuff when it's all on one page.
+
+	err := s.root.ForeachIssue(func(issue *github.Issue) error {
+		switch {
+		case opt.State == issues.StateFilter(issues.OpenState) && issues.State(*issue.State) != issues.OpenState:
+			return nil
+		case opt.State == issues.StateFilter(issues.ClosedState) && issues.State(*issue.State) != issues.ClosedState:
+			return nil
+		}
+
+		var labels []issues.Label
+		for _, l := range issue.Labels {
+			color, err := ghColor(l.Color)
+			if err != nil {
+				// issuemirror doesn't seem to provide label colors now, so fall back to white.
+				color = issues.RGB{R: 255, G: 255, B: 255}
+			}
+			labels = append(labels, issues.Label{
+				Name:  *l.Name,
+				Color: color,
+			})
+		}
+		is = append(is, issues.Issue{
+			ID:     uint64(*issue.Number),
+			State:  issues.State(*issue.State),
+			Title:  *issue.Title,
+			Labels: labels,
+			Comment: issues.Comment{
+				User:      ghUser(issue.User),
+				CreatedAt: *issue.CreatedAt,
+			},
+			Replies: *issue.Comments,
+		})
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Sort(sort.Reverse(byID(is)))
+
+	return is, nil
+}
+
+// byID implements sort.Interface.
+type byID []issues.Issue
+
+func (s byID) Len() int           { return len(s) }
+func (s byID) Less(i, j int) bool { return s[i].ID < s[j].ID }
+func (s byID) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// Count issues.
+func (s issuesService) Count(ctx context.Context, repo issues.RepoSpec, opt issues.IssueListOptions) (uint64, error) {
+	var count uint64
+
+	err := s.root.ForeachIssue(func(issue *github.Issue) error {
+		switch {
+		case opt.State == issues.StateFilter(issues.OpenState) && issues.State(*issue.State) != issues.OpenState:
+			return nil
+		case opt.State == issues.StateFilter(issues.ClosedState) && issues.State(*issue.State) != issues.ClosedState:
+			return nil
+		}
+
+		count++
+
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// Get an issue.
+func (s issuesService) Get(ctx context.Context, repo issues.RepoSpec, id uint64) (issues.Issue, error) {
+	issue, err := s.root.Issue(int(id))
+	if err != nil {
+		return issues.Issue{}, err
+	}
+
+	return issues.Issue{
+		ID:    uint64(*issue.Number),
+		State: issues.State(*issue.State),
+		Title: *issue.Title,
+		Comment: issues.Comment{
+			User:      ghUser(issue.User),
+			CreatedAt: *issue.CreatedAt,
+			Editable:  false,
+		},
+	}, nil
+}
+
+// ListComments lists comments for specified issue id.
+func (s issuesService) ListComments(ctx context.Context, repo issues.RepoSpec, id uint64, opt interface{}) ([]issues.Comment, error) {
+	var comments []issues.Comment
+
+	issue, err := s.root.Issue(int(id))
+	if err != nil {
+		return comments, err
+	}
+	comments = append(comments, issues.Comment{
+		ID:        0, // We use 0 as a special ID for the comment that is the issue description.
+		User:      ghUser(issue.User),
+		CreatedAt: *issue.CreatedAt,
+		Body:      *issue.Body,
+		Reactions: nil, // Doesn't seem to be exposed by issuemirror.
+		Editable:  false,
+	})
+
+	err = s.root.ForeachIssueComment(int(id), func(comment *github.IssueComment) error {
+		comments = append(comments, issues.Comment{
+			ID:        uint64(*comment.ID),
+			User:      ghUser(comment.User),
+			CreatedAt: *comment.CreatedAt,
+			Body:      *comment.Body,
+			Reactions: nil, // Doesn't seem to be exposed by issuemirror.
+			Editable:  false,
+		})
+
+		return nil
+	})
+	if err != nil {
+		return comments, err
+	}
+
+	return comments, nil
+}
+
+// ListEvents lists events for specified issue id.
+func (issuesService) ListEvents(ctx context.Context, repo issues.RepoSpec, id uint64, opt interface{}) ([]issues.Event, error) {
+	// For now, no events.
+	// Not sure if issuemirror exposes them. They're pretty optional, so look into this later.
+	return nil, nil
+}
+
+// Create a new issue.
+func (issuesService) Create(ctx context.Context, repo issues.RepoSpec, issue issues.Issue) (issues.Issue, error) {
+	return issues.Issue{}, fmt.Errorf("Create: not implemented")
+}
+
+// CreateComment creates a new comment for specified issue id.
+func (issuesService) CreateComment(ctx context.Context, repo issues.RepoSpec, id uint64, comment issues.Comment) (issues.Comment, error) {
+	return issues.Comment{}, fmt.Errorf("CreateComment: not implemented")
+}
+
+// Edit the specified issue id.
+func (issuesService) Edit(ctx context.Context, repo issues.RepoSpec, id uint64, ir issues.IssueRequest) (issues.Issue, []issues.Event, error) {
+	return issues.Issue{}, nil, fmt.Errorf("Edit: not implemented")
+}
+
+// EditComment edits comment of specified issue id.
+func (issuesService) EditComment(ctx context.Context, repo issues.RepoSpec, id uint64, cr issues.CommentRequest) (issues.Comment, error) {
+	return issues.Comment{}, fmt.Errorf("EditComment: not implemented")
+}
+
+// ghColor converts a GitHub user into a users.User.
+func ghUser(user *github.User) users.User {
+	return users.User{
+		UserSpec: users.UserSpec{
+			ID:     uint64(*user.ID),
+			Domain: "github.com",
+		},
+		Login:     *user.Login,
+		AvatarURL: template.URL(fmt.Sprintf("https://avatars.githubusercontent.com/u/%v?v=3", *user.ID)),
+		HTMLURL:   template.URL(fmt.Sprintf("https://github.com/%v", *user.Login)),
+	}
+}
+
+// ghColor converts a GitHub color hex string like "ff0000"
+// into an issues.RGB value.
+func ghColor(hex *string) (issues.RGB, error) {
+	if hex == nil {
+		return issues.RGB{}, errors.New("color value is missing")
+	}
+	var c issues.RGB
+	_, err := fmt.Sscanf(*hex, "%02x%02x%02x", &c.R, &c.G, &c.B)
+	if err != nil {
+		return issues.RGB{}, fmt.Errorf("color value %q has unexpected format, error parsing: %v", *hex, err)
+	}
+	return c, nil
+}
+
+// noUsersService implements users.Service without any users.
+// There can never be an authenticated user either.
+type noUsersService struct{}
+
+// Get fetches the specified user.
+func (noUsersService) Get(ctx context.Context, user users.UserSpec) (users.User, error) {
+	return users.User{}, fmt.Errorf("%v not found, this is a users service that contains no users", user)
+}
+
+// GetAuthenticatedSpec fetches the currently authenticated user specification,
+// or UserSpec{ID: 0} if there is no authenticated user.
+func (noUsersService) GetAuthenticatedSpec(ctx context.Context) (users.UserSpec, error) {
+	return users.UserSpec{}, nil
+}
+
+// GetAuthenticated fetches the currently authenticated user,
+// or User{UserSpec: UserSpec{ID: 0}} if there is no authenticated user.
+func (noUsersService) GetAuthenticated(ctx context.Context) (users.User, error) {
+	return users.User{}, nil
+}
+
+// Edit the authenticated user.
+func (noUsersService) Edit(ctx context.Context, er users.EditRequest) (users.User, error) {
+	return users.User{}, errors.New("Edit is not implemented")
+}


### PR DESCRIPTION
Hey @bradfitz,

I saw [your tweet](https://twitter.com/bradfitz/status/763090415843053568) about this this morning, and I instantly thought... You expose the data for all Go issues locally for fast access, and if I just implement the [`issues.Service` interface](https://godoc.org/github.com/shurcooL/issues#Service) on top of your [issuemirror API](https://godoc.org/github.com/bradfitz/issuemirror), then you could view all those issues locally in browser, even when offline.

(/cc @willnorris I've showed you those Go packages without context, but this is a more practical application of them :D)

Instead of more exciting things, I spent some effort in the past cleaning up some of the components to serve assets like Octicons, etc., locally, instead of https://cdnjs.cloudflare.com/ or the like, and used [vfsgen](https://github.com/shurcooL/vfsgen) to embed local assets like templates. Primarily because I wanted to make use of HTTP/2 for them, to avoid flash of unstyled content, and have a static Go binary with no external dependencies. The side benefit of doing that work is that everything can load even when offline!

So, without further ado, here's a little go-gettable command I wrote that takes in the issues via the API you expose, implements a simple `issues.Service` wrapper on top, and serves those so you can view them in browser locally or offline.
### Video Demo

[![image](https://cloud.githubusercontent.com/assets/1924134/17579652/91dd5d0e-5f4c-11e6-8982-2471fd28b71d.png)](https://www.youtube.com/watch?v=_JN4lMW1dcs)

https://www.youtube.com/watch?v=_JN4lMW1dcs
### Screenshots

![image](https://cloud.githubusercontent.com/assets/1924134/17579705/acecd5a2-5f4c-11e6-9643-b5cfb3db3279.png)

![image](https://cloud.githubusercontent.com/assets/1924134/17579707/b91112a8-5f4c-11e6-9593-0dd933e306bf.png)

![image](https://cloud.githubusercontent.com/assets/1924134/17579724/e8c31bcc-5f4c-11e6-81d9-a1d83f6afaaa.png)

Let me know what you think, I welcome feedback.
