### PR TITLE
issues: Simpler implementation of import path to absolute dir resolution.

### DIFF
--- a/issues/issues.go
+++ b/issues/issues.go
@@ -7,8 +7,7 @@
 package issues
 
 import (
-	"os"
-	"path/filepath"
+	"go/build"
 
 	"github.com/bradfitz/issuemirror"
 )
@@ -16,36 +15,20 @@ import (
 // Open returns the root of the Go issue mirror cache,
 // looking under $GOPATH/src/github.com/bradfitz/go-issue-mirror.
 func Open() (issuemirror.Root, error) {
-	root, err := goPackagePath("github.com/bradfitz/go-issue-mirror")
+	root, err := importPathToDir("github.com/bradfitz/go-issue-mirror")
 	if err != nil {
 		return "", err
 	}
 	return issuemirror.Root(root), nil
 }
 
-// goPackagePath returns the path to the provided Go package's
-// source directory.
-// pkg may be a path prefix without any *.go files.
-// The error is os.ErrNotExist if GOPATH is unset or the directory
-// doesn't exist in any GOPATH component.
-func goPackagePath(pkg string) (path string, err error) {
-	gp := os.Getenv("GOPATH")
-	if gp == "" {
-		return path, os.ErrNotExist
+// importPathToDir resolves the absolute path from importPath.
+// There doesn't need to be a valid Go package inside that import path,
+// but the directory must exist.
+func importPathToDir(importPath string) (string, error) {
+	p, err := build.Import(importPath, "", build.FindOnly)
+	if err != nil {
+		return "", err
 	}
-	for _, p := range filepath.SplitList(gp) {
-		dir := filepath.Join(p, "src", filepath.FromSlash(pkg))
-		fi, err := os.Stat(dir)
-		if os.IsNotExist(err) {
-			continue
-		}
-		if err != nil {
-			return "", err
-		}
-		if !fi.IsDir() {
-			continue
-		}
-		return dir, nil
-	}
-	return path, os.ErrNotExist
+	return p.Dir, nil
 }


### PR DESCRIPTION
I needed this functionality quite often in many packages, so over time I've come down to this solution. It uses `go/build.Import` with `build.FindOnly` flag. Given Go 1 promise, I think it's safe to rely on that behavior and there's no need to reimplement it from scratch.

It seems to be functionally equivalent to the previous code, but much shorter, simpler and easier to maintain.

This is an optional suggestion PR. I think it's a net improvement, but you're welcome to use your judgement and close this if you don't think it's an improvement.
