### PR TITLE
cmd/servegoissues: Use a more visible default label background color.

### DIFF
--- a/cmd/servegoissues/servegoissues.go
+++ b/cmd/servegoissues/servegoissues.go
@@ -131,8 +131,8 @@ func (s issuesService) List(ctx context.Context, repo issues.RepoSpec, opt issue
 		for _, l := range issue.Labels {
 			color, err := ghColor(l.Color)
 			if err != nil {
-				// issuemirror doesn't seem to provide label colors now, so fall back to white.
-				color = issues.RGB{R: 255, G: 255, B: 255}
+				// issuemirror doesn't seem to provide label colors now, so fall back to a default light gray.
+				color = issues.RGB{R: 0xed, G: 0xed, B: 0xed}
 			}
 			labels = append(labels, issues.Label{
 				Name:  *l.Name,


### PR DESCRIPTION
White labels on white background don't work really well, so use a light gray color for label backgrounds instead.

I think it makes the labels slightly easier to see, since they look more different than issue titles this way.

Before:

![image](https://cloud.githubusercontent.com/assets/1924134/17616123/87e99566-6027-11e6-8456-6652d00c0493.png)

After:

![image](https://cloud.githubusercontent.com/assets/1924134/17616131/8fffcb9e-6027-11e6-9317-1798462bb04a.png)

Btw, @bradfitz, if you want and think it's useful, you can make your dataset preserve the original label colors and they could be displayed. There'd be no need for code changes, the current code will be able to pick them up. Totally up to you.
