### PR TITLE
cmd/servegoissues: Replace "golang.org/x/net/context" with "context".

### DIFF
--- a/cmd/servegoissues/servegoissues.go
+++ b/cmd/servegoissues/servegoissues.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -17,7 +18,6 @@ import (
 	"github.com/shurcooL/issuesapp"
 	"github.com/shurcooL/issuesapp/common"
 	"github.com/shurcooL/users"
-	"golang.org/x/net/context"
 )
 
 var httpFlag = flag.String("http", ":8080", "Listen for HTTP connections on this address.")


### PR DESCRIPTION
Need to do this to be compatible with [`issues.Service` interface](https://godoc.org/github.com/shurcooL/issues#Service).

See shurcooL/issues@e84bcac62bdf13bda118bd2f843ae3187068af67.
