### PR TITLE
cmd/servegoissues: Update to use context from http.Request.

### DIFF
--- a/cmd/servegoissues/servegoissues.go
+++ b/cmd/servegoissues/servegoissues.go
@@ -33,9 +33,6 @@ func main() {
 	// We provide a simple read-only implementation of issues.Service on top of root,
 	// and a nil users service since this runs locally and doesn't need user authentication.
 	issuesApp := issuesapp.New(issuesService{root: root}, nil, issuesapp.Options{
-		Context: func(req *http.Request) context.Context {
-			return context.TODO()
-		},
 		RepoSpec: func(req *http.Request) issues.RepoSpec {
 			return issues.RepoSpec{URI: "github.com/golang/go"}
 		},


### PR DESCRIPTION
The change in shurcooL/issuesapp@59c941fc1f14849f78d2c5f34544f3ae6c82593e has made `issuesapp.Options.Context` unneccessary. Remove it.

This API simplification is made possible by the change in Go 1.7 where each `http.Request` comes with a context associated with it. Previously, an external library (such as [`github.com/gorilla/context`](https://godoc.org/github.com/gorilla/context)) had to be used to provide this functionality, and so one of the options was to specify how to extract a context from an `*http.Request`.

Since it's a part of the standard library, it's possible for everyone to use it, and this no longer needs to be provided externally or customizable.

Fixes #8.
