### PR TITLE
cmd/servegoissues: Display link to view original issue.

### DIFF
--- a/cmd/servegoissues/servegoissues.go
+++ b/cmd/servegoissues/servegoissues.go
@@ -76,6 +76,11 @@ func main() {
 		box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
 	}
 </style>`,
+		BodyPre: `
+{{/* Override new comment component to link to original issue for leaving comments. */}}
+{{define "new-comment"}}<div class="event" style="margin-top: 20px; margin-bottom: 100px;">
+	View <a href="https://github.com/golang/go/issues/{{.Issue.ID}}#new_comment_field">original issue</a> to comment.
+</div>{{end}}`,
 	})
 
 	http.Handle("/", issuesApp)


### PR DESCRIPTION
Previously, it would display a "Sign in to comment" message which was not applicable to this view-only Go issue viewer. User logins are not supported here. Even if they were, it wouldn't make sense to post new comments to a mirror of Go issues.

Before:

![image](https://cloud.githubusercontent.com/assets/1924134/18031938/012c6ec4-6caa-11e6-8f24-8c2a0dfc869b.png)

After:

![image](https://cloud.githubusercontent.com/assets/1924134/18032034/1ed3bd84-6cae-11e6-8b8f-5166be00a029.png)

Resolves #9. /cc @rakyll
