### PR TITLE
cmd/servegoissues: Disable reactions.

### DIFF
--- a/cmd/servegoissues/servegoissues.go
+++ b/cmd/servegoissues/servegoissues.go
@@ -33,6 +33,8 @@ func main() {
 	// We provide a simple read-only implementation of issues.Service on top of root,
 	// and a nil users service since this runs locally and doesn't need user authentication.
 	issuesApp := issuesapp.New(issuesService{root: root}, nil, issuesapp.Options{
+		DisableReactions: true,
+
 		RepoSpec: func(req *http.Request) issues.RepoSpec {
 			return issues.RepoSpec{URI: "github.com/golang/go"}
 		},


### PR DESCRIPTION
The new issuesapp API (see shurcooL/issuesapp#1) requires the user to provide emojis (they are now served locally rather than from the internet), unless `DisableReactions` option is true (it's available as of shurcooL/issuesapp@c6bf1874c9ed7956a04ab06f039a8516f30d73d1).

Given that the Go issues data does not include any reactions, and it's not possible to login to react, it seems to make more sense to outright remove them.

@bradfitz Let me know if that's what you prefer to do. The alternative is to not disable reactions. But then you'll need to serve emojis locally to avoid 404s if users open the "React" menu. It would be a matter of adding:

``` Go
import "github.com/shurcooL/reactions/emojis"
```

``` Go
emojisHandler := httpgzip.FileServer(emojis.Assets, httpgzip.FileServerOptions{})
http.Handle("/emojis/", http.StripPrefix("/emojis", emojisHandler))
```
## Screenshots

Some screenshots to visualize what this PR changes.
### Before

![image](https://cloud.githubusercontent.com/assets/1924134/19408040/7106195a-9268-11e6-9b37-9ac8ecf86cde.png)
### After

Notice the "React" button in top right corner of each comment is now hidden. All reactions, if they were present in the underlying data, are hidden too (but there are none included anyway).

![image](https://cloud.githubusercontent.com/assets/1924134/19408042/7747b922-9268-11e6-98a2-e95a5cc633a6.png)
### On GitHub

For reference, this is what the [same issue](https://github.com/golang/go/issues/15123) looks like on GitHub:

![image](https://cloud.githubusercontent.com/assets/1924134/19408048/8d2e1844-9268-11e6-990a-10d715beb291.png)
