### PR TITLE
issues: Simplify code to find the root directory.

### DIFF
--- a/issues/issues.go
+++ b/issues/issues.go
@@ -8,19 +8,18 @@ package issues
 
 import (
 	"go/build"
-	"path/filepath"
 
 	"github.com/bradfitz/issuemirror"
 )
 
 // Open returns the root of the Go issue mirror cache,
-// looking under $GOPATH/src/github.com/bradfitz/go-issue-mirror.
+// looking under $GOPATH/src/github.com/bradfitz/go-issue-mirror/_data.
 func Open() (issuemirror.Root, error) {
-	root, err := importPathToDir("github.com/bradfitz/go-issue-mirror")
+	root, err := importPathToDir("github.com/bradfitz/go-issue-mirror/_data")
 	if err != nil {
 		return "", err
 	}
-	return issuemirror.Root(filepath.Join(root, "_data")), nil
+	return issuemirror.Root(root), nil
 }
 
 // importPathToDir resolves the absolute path from importPath.


### PR DESCRIPTION
`build.Import`, when given an blank `srcDir` and `build.FindOnly` mode, simply finds an existing directory within GOPATH workspaces, it does not check if there's an existing Go package there. (For reference, the previous import path "github.com/bradfitz/go-issue-mirror" also did not have an actual Go package inside, its directory contains README.md and no .go files.)

Additionally, when given an explicit full import path, the logic doesn't care if there are elements that begin with _, . or are equal to testdata. That only matters when expanding patterns or listing all Go packages.

So, there's no reason to use `importPathToDir` to find a parent directory, and then use `filepath.Join` to join that path with _data subdirectory. It's simpler to just use `importPathToDir` to directly resolve the target directory.
