### PR TITLE
cmd/servegoissues: Update issues.Service interface.

### DIFF
--- a/cmd/servegoissues/servegoissues.go
+++ b/cmd/servegoissues/servegoissues.go
@@ -214,7 +214,9 @@ func (s issuesService) Get(ctx context.Context, repo issues.RepoSpec, id uint64)
 }
 
 // ListComments lists comments for specified issue id.
-func (s issuesService) ListComments(ctx context.Context, repo issues.RepoSpec, id uint64, opt interface{}) ([]issues.Comment, error) {
+func (s issuesService) ListComments(ctx context.Context, repo issues.RepoSpec, id uint64, opt *issues.ListOptions) ([]issues.Comment, error) {
+	// TODO: Pagination. Respect opt.Start and opt.Length, if given.
+
 	var comments []issues.Comment
 
 	issue, err := s.root.Issue(int(id))
@@ -250,7 +252,7 @@ func (s issuesService) ListComments(ctx context.Context, repo issues.RepoSpec, i
 }
 
 // ListEvents lists events for specified issue id.
-func (issuesService) ListEvents(ctx context.Context, repo issues.RepoSpec, id uint64, opt interface{}) ([]issues.Event, error) {
+func (issuesService) ListEvents(ctx context.Context, repo issues.RepoSpec, id uint64, opt *issues.ListOptions) ([]issues.Event, error) {
 	// For now, no events.
 	// Not sure if issuemirror exposes them. They're pretty optional, so look into this later.
 	return nil, nil


### PR DESCRIPTION
Update for shurcooL/issues@d5974e9a15c00a1f96671d2405bc6d52571f1d5a.

This change is needed to fix what otherwise would be a build error:

```bash
$ go build -o /dev/null github.com/bradfitz/go-issue-mirror/cmd/servegoissues
# github.com/bradfitz/go-issue-mirror/cmd/servegoissues
cmd/servegoissues/servegoissues.go:36: cannot use issuesService literal (type issuesService) as type "github.com/shurcooL/issues".Service in argument to issuesapp.New:
	issuesService does not implement "github.com/shurcooL/issues".Service (wrong type for ListComments method)
		have ListComments(context.Context, "github.com/shurcooL/issues".RepoSpec, uint64, interface {}) ([]"github.com/shurcooL/issues".Comment, error)
		want ListComments(context.Context, "github.com/shurcooL/issues".RepoSpec, uint64, *"github.com/shurcooL/issues".ListOptions) ([]"github.com/shurcooL/issues".Comment, error)
```