### PR TITLE
cmd/servegoissues: Update for users API change.

### DIFF
--- a/cmd/servegoissues/servegoissues.go
+++ b/cmd/servegoissues/servegoissues.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"html/template"
 	"log"
 	"net/http"
 	"sort"
@@ -267,8 +266,8 @@ func ghUser(user *github.User) users.User {
 			Domain: "github.com",
 		},
 		Login:     *user.Login,
-		AvatarURL: template.URL(fmt.Sprintf("https://avatars.githubusercontent.com/u/%v?v=3", *user.ID)),
-		HTMLURL:   template.URL(fmt.Sprintf("https://github.com/%v", *user.Login)),
+		AvatarURL: fmt.Sprintf("https://avatars.githubusercontent.com/u/%v?v=3", *user.ID),
+		HTMLURL:   fmt.Sprintf("https://github.com/%v", *user.Login),
 	}
 }
 

--- a/cmd/servegoissues/servegoissues.go
+++ b/cmd/servegoissues/servegoissues.go
@@ -229,11 +229,7 @@ func (s issuesService) ListComments(ctx context.Context, repo issues.RepoSpec, i
 
 		return nil
 	})
-	if err != nil {
-		return comments, err
-	}
-
-	return comments, nil
+	return comments, err
 }
 
 // ListEvents lists events for specified issue id.
@@ -263,7 +259,7 @@ func (issuesService) EditComment(ctx context.Context, repo issues.RepoSpec, id u
 	return issues.Comment{}, fmt.Errorf("EditComment: not implemented")
 }
 
-// ghColor converts a GitHub user into a users.User.
+// ghUser converts a GitHub user into a users.User.
 func ghUser(user *github.User) users.User {
 	return users.User{
 		UserSpec: users.UserSpec{


### PR DESCRIPTION
The users API has been changed to use `string` type instead of `template.URL` in https://github.com/shurcooL/users/commit/155c11a29d1e03a3b29f4f9d7068ca7bae9ebc27. See its commit message for rationale:

> Given we're moving away from use of html/template (e.g., see shurcooL/notificationsapp#3 and shurcooL/Go-Package-Store#68), it's no longer worth it to import the entire html/template package only for its URL type.
>
> It's simpler to use string and add URL to the variable name to indicate that it's a URL.

This PR updates the use of the API so that the build of `cmd/servegoissues` succeeds.

It also includes minor typo fix in a comment and a return statement simplification.