### PR TITLE
cmd/servegoissues: Deprecate in favor of maintserve.

### DIFF
--- a/cmd/servegoissues/servegoissues.go
+++ b/cmd/servegoissues/servegoissues.go
@@ -3,6 +3,9 @@
 // license that can be found in the LICENSE file.
 
 // servegoissues is a program that serves Go issues over HTTP, so they can be viewed in a browser.
+//
+// Deprecated: Use golang.org/x/build/maintner/cmd/maintserve instead. maintserve is a more
+// modern, featureful, and supported tool which completely supercedes servegoissues.
 package main
 
 import (


### PR DESCRIPTION
[`maintserve`](https://godoc.org/golang.org/x/build/maintner/cmd/maintserve) supercedes `servegoissues`. Make this note so that it's clear that `maintserve` should be used instead. Also, I'm not maintaining/supporting `servegoissues` anymore, so I want that to be documented too.

Updates #7.